### PR TITLE
 Potential Building Bug in Geojson and json controller

### DIFF
--- a/app/controllers/api/json_controller.rb
+++ b/app/controllers/api/json_controller.rb
@@ -6,6 +6,7 @@ module Api
  
     def json
       @buildings =  @@search_controller.search_buildings(params["search"],params["year"])
+      binding.pry
       @ready_buildings =[]
       @buildings.each{|building|  @ready_buildings.append(make_building(building,params["year"])) } 
       @ready_buildings = @ready_buildings.compact


### PR DESCRIPTION
 potential bug that seems to affect both the JSON controller and the GEOJSON controller
First I noticed that when a document is attached only to a building, searching that documents  name, doesn't bring up the building its attached to. it does bring back  the Document in the JSON controller.
Second, is that both controllers dont seem to be making and displaying the json for  the building, that is attached  to a document,narrative, or photo.
For example:
if we Attach only a building(no census records in 1910 or 1920) to a narrative in  the dev branch
 then the building attached shows up in Both, but not 1910 1920
 if we attach only a building(no census records in 1910 or 1920) to a document in dev branch
Doesn't show up in Both,1910,1920 (I believe this is because the search doesn't find the building through the document name at all)