### PR TITLE
Refactors GeoJSON API to return all years' data

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -5,9 +5,7 @@ module Api
     def search_buildings(target,target_year)
       census_query     = ''
       building_query   = ''
-      census1910_query = ''
-      person_query1910 = ''
-      person_query1920 = ''
+      person_query = ''
       audio_query      = ''
       video_query      = ''
       documents_query  = ''
@@ -15,12 +13,10 @@ module Api
       narrative_query  = ''
       rich_text_query  = ''
       address_query    = ''
-
-      census_query     = search_query('Census1920Record',census_query)
-      census1910_query = search_query('Census1910Record',census1910_query)
+      
+      census_query     = search_query("Census#{target_year}Record",census_query)
       building_query   = search_query('Building',building_query)
-      person_query1910 = search_query('Person',person_query1910)
-      person_query1920 = search_query('Person',person_query1920)
+      person_query = search_query('Person',person_query)
       audio_query      = search_query('Audio',audio_query)
       video_query      = search_query('Video',video_query)
       photo_query      = search_query('Photograph',photo_query)
@@ -31,9 +27,7 @@ module Api
 
       building_query   = building_query.chomp('OR ')
       census_query     = census_query.chomp('OR ')
-      census1910_query = census1910_query.chomp('OR ')
-      person_query1910 = person_query1910.chomp('OR ')
-      person_query1920 = person_query1920.chomp('OR ')
+      person_query = person_query.chomp('OR ')
       audio_query      = audio_query.chomp('OR ')
       video_query      = video_query.chomp('OR ')
       photo_query      = photo_query.chomp('OR ')
@@ -43,7 +37,7 @@ module Api
       documents_query  = documents_query.chomp('OR ')
 
       if target.present?
-        if target_year == 'Both'
+        
           buildings = Building.where(building_query,:search => "%#{target}%").ids.uniq
           building_photo = Building.joins(:photos).where('Photographs.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
           building_video = Building.joins(:videos).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
@@ -54,81 +48,23 @@ module Api
           building_action_text_description = Building.joins(:rich_text_description).where(rich_text_query,:search => "%#{target}%").ids.uniq
           building_address = Building.joins(:addresses).where(address_query,:search => "%#{target}%").ids.uniq
 
-          buildings2 = Building.joins(:census1920_records).where(census_query,:search => "%#{target}%").ids.uniq
-          buildings3 = Building.joins(:census1910_records).where(census1910_query,:search => "%#{target}%").ids.uniq
-          buildings_people1920 = Building.joins(:people_1920).where(person_query1920,:search => "%#{target}%").ids.uniq
-          people_photo1920 = Building.joins(people_1920: :photos).where('Photographs.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_video1920 = Building.joins(people_1920: :videos).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_audio1920 = Building.joins(people_1920: :audios).where('Audios.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_narrative1920 = Building.joins(people_1920: :narratives).where(narrative_query,:search => "%#{target}%").ids.uniq
-          people_document1920 = Building.joins(people_1920: :documents).where(documents_query,:search => "%#{target}%").ids.uniq
-          buildings_people1910 = Building.joins(:people_1910).where(person_query1910,:search => "%#{target}%").ids.uniq
-          people_photo1910 = Building.joins(people_1910: :photos).where('Photographs.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_video1910 = Building.joins(people_1910: :videos).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_audio1910 = Building.joins(people_1910: :audios).where('Audios.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_narrative1910 = Building.joins(people_1910: :narratives).where(narrative_query,:search => "%#{target}%").ids.uniq
-          people_document1910 = Building.joins(people_1910: :documents).where(documents_query,:search => "%#{target}%").ids.uniq
-
-          narrative_action_text_story1910 = Building.joins(people_1910: [{narratives: :rich_text_story}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          narrative_action_text_sources1910 = Building.joins(people_1910: [{narratives: :rich_text_sources}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
-
-          narrative_action_text_story1920 = Building.joins(people_1920: [{narratives: :rich_text_story}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          narrative_action_text_sources1920 = Building.joins(people_1920: [{narratives: :rich_text_sources}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
-
-          buildings << building_photo
-          buildings << building_video
-          buildings << building_audio
-          buildings << building_narrative
-          buildings << building_action_text_sources
-          buildings << building_action_text_story
-          buildings << building_action_text_description
-          buildings << building_address
-
-          buildings << buildings2
-          buildings << buildings3
-          buildings << buildings_people1920
-          buildings << people_photo1920
-          buildings << people_video1920
-          buildings << people_audio1920
-          buildings << people_narrative1920
-          buildings << people_document1920
-
-          buildings << buildings_people1910
-          buildings << people_photo1910
-          buildings << people_video1910
-          buildings << people_audio1910
-          buildings << people_narrative1910
-          buildings << people_document1910
           
-          buildings << narrative_action_text_story1910
-          buildings << narrative_action_text_sources1910
+          census_record_year = :"census#{target_year}_records"
+          people_year = :"people_#{target_year}"
+          
+          
+          
+          buildings_census = Building.joins(census_record_year).where(census_query,:search => "%#{target}%").ids.uniq
+          buildings_people = Building.joins(people_year).where(person_query,:search => "%#{target}%").ids.uniq
+          
+          people_photo = Building.joins({ people_year => :photos }).where('photographs.searchable_text::varchar ILIKE ?', "%#{target}%").distinct.ids
+          people_video = Building.joins({ people_year =>  :videos}).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
+          people_audio = Building.joins({ people_year => :audios}).where('Audios.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
+          people_narrative = Building.joins({ people_year => :narratives}).where(narrative_query,:search => "%#{target}%").ids.uniq
+          people_document = Building.joins({ people_year => :documents}).where(documents_query,:search => "%#{target}%").ids.uniq
 
-          buildings << narrative_action_text_story1920
-          buildings << narrative_action_text_sources1920
-          buildings = buildings.flatten.uniq
-          buildings = Building.where(id: buildings)
-
-        elsif target_year == '1910'
-          buildings = Building.where(building_query,:search => "%#{target}%").ids.uniq
-          building_photo = Building.joins(:photos).where('Photographs.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          building_video = Building.joins(:videos).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          building_audio = Building.joins(:audios).where('Audios.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          building_narrative = Building.joins(:narratives).where(narrative_query,:search => "%#{target}%").ids.uniq
-          building_action_text_story = Building.joins(narratives: :rich_text_story).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          building_action_text_sources = Building.joins(narratives: :rich_text_sources).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          building_action_text_description = Building.joins(:rich_text_description).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          building_address = Building.joins(:addresses).where(address_query,:search => "%#{target}%").ids.uniq
-
-          buildings3 = Building.joins(:census1910_records).where(census1910_query,:search => "%#{target}%").ids.uniq
-          buildings_people1910 = Building.joins(:people_1910).where(person_query1910,:search => "%#{target}%").ids.uniq
-          people_photo1910 = Building.joins(people_1910: :photos).where('Photographs.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_video1910 = Building.joins(people_1910: :videos).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_audio1910 = Building.joins(people_1910: :audios).where('Audios.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_narrative1910 = Building.joins(people_1910: :narratives).where(narrative_query,:search => "%#{target}%").ids.uniq
-          people_document1910 = Building.joins(people_1910: :documents).where(documents_query,:search => "%#{target}%").ids.uniq
-
-          narrative_action_text_story1910 = Building.joins(people_1910: [{narratives: :rich_text_story}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          narrative_action_text_sources1910 = Building.joins(people_1910: [{narratives: :rich_text_sources}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
+          narrative_action_text_story = Building.joins({people_year => [{narratives: :rich_text_story}]}).where(rich_text_query,:search => "%#{target}%").ids.uniq
+          narrative_action_text_sources = Building.joins({people_year => [{narratives: :rich_text_sources}]}).where(rich_text_query,:search => "%#{target}%").ids.uniq
 
           buildings << building_photo
           buildings << building_video
@@ -139,65 +75,21 @@ module Api
           buildings << building_action_text_description
           buildings << building_address
 
-          buildings << buildings3
-          buildings << buildings_people1910
-          buildings << people_photo1910
-          buildings << people_video1910
-          buildings << people_audio1910
-          buildings << people_narrative1910
-          buildings << people_document1910
+          buildings << buildings_census
+          buildings << buildings_people
+          buildings << people_photo
+          buildings << people_video
+          buildings << people_audio
+          buildings << people_narrative
+          buildings << people_document
 
-          buildings << narrative_action_text_story1910
-          buildings << narrative_action_text_sources1910
-
-          buildings = buildings.flatten.uniq
-          buildings = Building.where(id: buildings)
-
-        elsif target_year == '1920'
-          buildings = Building.where(building_query,:search => "%#{target}%").ids.uniq
-          building_photo = Building.joins(:photos).where('Photographs.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          building_video = Building.joins(:videos).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          building_audio = Building.joins(:audios).where('Audios.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          building_narrative = Building.joins(:narratives).where(narrative_query,:search => "%#{target}%").ids.uniq
-          building_action_text_story = Building.joins(narratives: :rich_text_story).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          building_action_text_sources = Building.joins(narratives: :rich_text_sources).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          building_action_text_description = Building.joins(:rich_text_description).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          building_address = Building.joins(:addresses).where(address_query,:search => "%#{target}%").ids.uniq
-
-          buildings2 = Building.joins(:census1920_records).where(census_query,:search => "%#{target}%").ids.uniq 
-          buildings_people1920 = Building.joins(:people_1920).where(person_query1920,:search => "%#{target}%").ids.uniq
-          people_photo1920 = Building.joins(people_1920: :photos).where('Photographs.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_video1920 = Building.joins(people_1920: :videos).where('Videos.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_audio1920 = Building.joins(people_1920: :audios).where('Audios.searchable_text::varchar ILIKE :search',:search => "%#{target}%").ids.uniq
-          people_narrative1920 = Building.joins(people_1920: :narratives).where(narrative_query,:search => "%#{target}%").ids.uniq
-          people_document1920 = Building.joins(people_1920: :documents).where(documents_query,:search => "%#{target}%").ids.uniq
-
-          narrative_action_text_story1920 = Building.joins(people_1920: [{narratives: :rich_text_story}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
-          narrative_action_text_sources1920 = Building.joins(people_1920: [{narratives: :rich_text_sources}]).where(rich_text_query,:search => "%#{target}%").ids.uniq
-
-          buildings << building_photo
-          buildings << building_video
-          buildings << building_audio
-          buildings << building_narrative
-          buildings << building_action_text_sources
-          buildings << building_action_text_story
-          buildings << building_action_text_description
-          buildings << building_address
-
-          buildings << buildings2
-          buildings << buildings_people1920
-          buildings << people_photo1920
-          buildings << people_video1920
-          buildings << people_audio1920
-          buildings << people_narrative1920
-          buildings << people_document1920
-
-          buildings << narrative_action_text_story1920
-          buildings << narrative_action_text_sources1920
+          buildings << narrative_action_text_story
+          buildings << narrative_action_text_sources
 
           buildings = buildings.flatten.uniq
           buildings = Building.where(id: buildings)
-        end
+
+        
       else
         buildings = Building.all
       end
@@ -205,13 +97,20 @@ module Api
     end
 
     def search
-      @buildings = search_buildings(params['search'],params['year'])
+      @ready_geojson=[]
+      list_years = ['1910','1920']
+      list_years.each do |year|
+      @buildings = search_buildings(params['search'],year)
       @ready_buildings =[]
+      
 
-      @buildings.each{|building|  @ready_buildings.append(make_feature(building,params['year'])) }
-      @geojson = build_geojson
+      @buildings.each{|building|  @ready_buildings.append(make_feature(building,year)) }
+      @geojson = build_geojson(year)
+      @ready_geojson.append(@geojson)
+      end
+      
       response.set_header('Access-Control-Allow-Origin', '*')
-      render json: @geojson
+      render json: @ready_geojson
     end
 
     private def search_query(class_name,chosen_query)
@@ -227,11 +126,14 @@ module Api
     end
 
 
-    private def build_geojson
-      {
-        type: 'FeatureCollection',
-        features: @ready_buildings
-      }
+    private def build_geojson(year)
+      rough_geojson = { 
+             year => {
+                    type: 'FeatureCollection',
+                    features: @ready_buildings
+                    }
+    }
+    return rough_geojson
 
     end
 
@@ -262,56 +164,7 @@ module Api
       if record.photos.empty? == false
       record.photos.each {|photo| building_photos.append({record: photo,attatchment:photo.file_attachment,url:rails_blob_url(photo.file_attachment, only_path: true)}) }
       end
-      if year == '1920'
-
-        feature = {
-          'type': 'Feature',
-          'geometry': {
-            'type': 'Point',
-            'coordinates': record.coordinates
-          },
-          'properties': {
-            'location_id': record.id,
-            'title': record.primary_street_address,
-            'addresses': record.addresses,
-            'audios': record.audios,
-            'narratives': building_narratives,
-            'videos': record.videos,
-            'photos': building_photos,
-            'description': record.full_street_address,
-            'rich_description': record.rich_text_description,
-            '1910': [],
-            '1920': record.census1920_records,
-            '1910_people': [],
-            '1920_people': person_array_1920
-          }
-        }
-
-      elsif year == '1910'
-        feature = {
-          'type': 'Feature',
-          'geometry': {
-            'type': 'Point',
-            'coordinates': record.coordinates
-          },
-        'properties': {
-            'location_id': record.id,
-            'title':  record.primary_street_address,
-            'addresses': record.addresses,
-            'audios': record.audios,
-            'narratives': building_narratives,
-            'videos': record.videos,
-            'photos': building_photos,
-            'description': record.full_street_address,
-            'rich_description': record.rich_text_description,
-            '1910': record.census1910_records,
-            '1920': [],
-            '1910_people': person_array_1910,
-            '1920_people': []
-          }
-        }
-
-      elsif year == 'Both'
+      
         feature = {
           'type': 'Feature',
           'geometry': {
@@ -328,13 +181,13 @@ module Api
             'photos': building_photos,
             'description': record.full_street_address,
             'rich_description': record.rich_text_description,
-            '1910': record.census1910_records,
-            '1920': record.census1920_records,
-            '1910_people': person_array_1910,
-            '1920_people': person_array_1920
+            '1910': year == '1910' ? record.census1910_records : [],
+            '1920':year == '1920' ? record.census1920_records : [],
+            '1910_people': year == '1910' ? person_array_1910 : [],
+            '1920_people': year == '1920' ? person_array_1920 : []
           }
         }
-      end
+      
 
       if feature[:properties][:'1920'].empty? && year == '1920'
         return


### PR DESCRIPTION
Refactors the GeoJSON API to fetch and return data for both 1910 and 1920, providing a more comprehensive dataset.

- Modifies the API to iterate through both 1910 and 1920.
- Combines the results into a single JSON response.
- Includes total counts for each category across all years.

Fixes #71